### PR TITLE
Fix Invisible Legs Bug

### DIFF
--- a/Common/PlayerLayers/RaceBackArm.cs
+++ b/Common/PlayerLayers/RaceBackArm.cs
@@ -103,7 +103,6 @@ namespace MrPlagueRaces.Common
 							drawInfo.DrawDataCache.Add(new DrawData(Undershirt_Texture[drawInfo.skinVar].Value, bodyPosition, drawInfo.compBackShoulderFrame, drawInfo.colorUnderShirt, bodyRotation, drawInfo.bodyVect, 1f, drawInfo.playerEffect, 0));
 							drawInfo.DrawDataCache.Add(new DrawData(Shirt_Texture[drawInfo.skinVar].Value, bodyPosition, drawInfo.compBackShoulderFrame, drawInfo.colorShirt, bodyRotation, drawInfo.bodyVect, 1f, drawInfo.playerEffect, 0));
 						}
-						drawPlayer.invis = true;
 					}
 				}
 				if (!drawPlayer.invis)


### PR DESCRIPTION
When a body equip in the `ArmorIDs.Body.Sets.HidesArms` set was drawn, the player's legs would mysteriously disappear.
This fixes that.

Reproduction:
1. Enable this mod and load any character.
2. Wear the [Robot Shirt](https://terraria.wiki.gg/wiki/Robot_set).
3. Ponder the nature of your surprise double-amputation.

Before:
![image](https://github.com/Mr-Plauge/MrPlagueRaces-1.4/assets/33076411/c55318de-8f35-447e-b99e-7858bcdc2a6b)
After:
![image](https://github.com/Mr-Plauge/MrPlagueRaces-1.4/assets/33076411/00497a01-40eb-4515-8cb1-c00eef475227)