### PR TITLE
Fix Tabaxi dash velocity scaling for negative values

### DIFF
--- a/Common/Races/Tabaxi/Tabaxi.cs
+++ b/Common/Races/Tabaxi/Tabaxi.cs
@@ -215,8 +215,8 @@ namespace MrPlagueRaces.Common.Races.Tabaxi
                         {
                             player.controlUseItem = false;
                         }
-                        Vector2 velocity = ((Vector2.Normalize(mrPlagueRacesPlayer.mouseWorld - player.Center) * tabaxiPlayer.phaseActiveCounter * 5f) * (tabaxiPlayer.meetsIntangibilityRequirement(ModContent.GetInstance<TabaxiConfig>().tabaxiIntangibility) ? 1f : 0.4f)) * (int)(1f + StatConfigHelpers.RacialStatPercentageFloatIndex[(int)ModContent.GetInstance<TabaxiConfig>().tabaxiDashVelocity]);
-						player.maxFallSpeed = 1000000f;
+                        Vector2 velocity = ((Vector2.Normalize(mrPlagueRacesPlayer.mouseWorld - player.Center) * tabaxiPlayer.phaseActiveCounter * 5f) * (tabaxiPlayer.meetsIntangibilityRequirement(ModContent.GetInstance<TabaxiConfig>().tabaxiIntangibility) ? 1f : 0.4f)) * (1f + StatConfigHelpers.RacialStatPercentageFloatIndex[(int)ModContent.GetInstance<TabaxiConfig>().tabaxiDashVelocity]);
+                        player.maxFallSpeed = 1000000f;
 						player.gravity = 0f;
                         player.velocity = velocity;
 						if (player.controlUp) {


### PR DESCRIPTION
### Problem
When Tabaxi dash velocity is set below 0% in config,
the dash distance becomes 0 tiles regardless of the value.

### Cause
The velocity multiplier was cast to int, causing all values
between -99% and +99% to evaluate to 0 or 1.

### Solution
- Removed int cast from dash velocity multiplier

### Testing
- Tested with -100%, -90%, -60%, -10%, 0%, +50%, +100%